### PR TITLE
Buffer improvements

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -15,10 +15,10 @@ pub struct Buffer2d<T> {
 }
 
 impl<T: Clone> Buffer2d<T> {
-    pub fn new(size: [usize; 2], fill: T) -> Self {
+    pub fn new([width, height]: [usize; 2], fill: T) -> Self {
         Self {
-            items: vec![fill; size[0] * size[1]],
-            size,
+            items: vec![fill; width * height],
+            size: [width, height],
         }
     }
 }
@@ -32,13 +32,15 @@ impl<T: Clone> Target for Buffer2d<T> {
     }
 
     #[inline(always)]
-    unsafe fn set(&mut self, pos: [usize; 2], item: Self::Item) {
-        *self.items.get_unchecked_mut(pos[1] * self.size[0] + pos[0]) = item;
+    unsafe fn set(&mut self, [x, y]: [usize; 2], item: Self::Item) {
+        let [width, _] = self.size;
+        *self.items.get_unchecked_mut(y * width + x) = item;
     }
 
     #[inline(always)]
-    unsafe fn get(&self, pos: [usize; 2]) -> &Self::Item {
-        &self.items.get_unchecked(pos[1] * self.size[0] + pos[0])
+    unsafe fn get(&self, [x, y]: [usize; 2]) -> &Self::Item {
+        let [width, _] = self.size;
+        &self.items.get_unchecked(y * width + x)
     }
 
     fn clear(&mut self, fill: Self::Item) {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -42,7 +42,9 @@ impl<T: Clone> Target for Buffer2d<T> {
     }
 
     fn clear(&mut self, fill: Self::Item) {
-        self.items = vec![fill; self.size[0] * self.size[1]];
+        for item in &mut self.items {
+            *item = fill.clone();
+        }
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -52,6 +52,12 @@ impl<T> AsRef<[T]> for Buffer2d<T> {
     }
 }
 
+impl<T> AsMut<[T]> for Buffer2d<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        &mut self.items
+    }
+}
+
 impl<T> fmt::Debug for Buffer2d<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Buffer2d(dimensions: {:?})", self.size)


### PR DESCRIPTION
This PR does three things to `Buffer2d`:

- [x] Changes the implementation of `clear()` to not re-allocate the data buffer (modifies in-place instead)
- [x] Implements `AsMut<[T]>` for `Buffer2d` so that it [can be used with rayon](https://docs.rs/rayon/1.0.3/rayon/iter/trait.IntoParallelIterator.html#impl-IntoParallelIterator-27)
- [x] Uses [irrefutable patterns](https://doc.rust-lang.org/book/ch18-02-refutability.html) to make the code easier to read / understand / check for correctness

Thanks for such an excellent library! I'm using it for a project and I'm glad to be able to contribute back to it. :)