### PR TITLE
Always cloning in get() to allow for any underlying representation

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -38,9 +38,9 @@ impl<T: Clone> Target for Buffer2d<T> {
     }
 
     #[inline(always)]
-    unsafe fn get(&self, [x, y]: [usize; 2]) -> &Self::Item {
+    unsafe fn get(&self, [x, y]: [usize; 2]) -> Self::Item {
         let [width, _] = self.size;
-        &self.items.get_unchecked(y * width + x)
+        self.items.get_unchecked(y * width + x).clone()
     }
 
     fn clear(&mut self, fill: Self::Item) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Target {
     /// Get a copy of the item at the specified location in the target. The validity of the
     /// location is not checked, and as such this method is marked `unsafe`.
     #[inline(always)]
-    unsafe fn get(&self, pos: [usize; 2]) -> &Self::Item;
+    unsafe fn get(&self, pos: [usize; 2]) -> Self::Item;
 
     /// Clear the target with copies of the specified item.
     fn clear(&mut self, fill: Self::Item);

--- a/src/rasterizer/lines.rs
+++ b/src/rasterizer/lines.rs
@@ -72,7 +72,7 @@ impl<'a, D: Target<Item=f32>> Rasterizer for Lines<'a, D> {
                         let (x, y) = (x as usize, y as usize);
 
                         // Depth test
-                        if z_lerped < unsafe { *depth.get([x, y]) } {
+                        if z_lerped < unsafe { depth.get([x, y]) } {
                             // Calculate the interpolated vertex attributes of this fragment
                             let vs_out_lerped = P::VsOut::lerp2(
                                 l_vs_out.clone(),
@@ -112,7 +112,7 @@ impl<'a, D: Target<Item=f32>> Rasterizer for Lines<'a, D> {
                         let (x, y) = (x as usize, y as usize);
 
                         // Depth test
-                        if z_lerped < unsafe { *depth.get([x, y]) } {
+                        if z_lerped < unsafe { depth.get([x, y]) } {
                             // Calculate the interpolated vertex attributes of this fragment
                             let vs_out_lerped = P::VsOut::lerp2(
                                 l_vs_out.clone(),

--- a/src/rasterizer/triangles.rs
+++ b/src/rasterizer/triangles.rs
@@ -119,9 +119,9 @@ impl<'a, D: Target<Item=f32>, B: BackfaceMode> Rasterizer for Triangles<'a, D, B
                         // Depth test
                         let should_draw = match pipeline.get_depth_strategy() {
                             DepthStrategy::IfLessWrite | DepthStrategy::IfLessNoWrite =>
-                                z_lerped < unsafe { *depth.get([x, y]) },
+                                z_lerped < unsafe { depth.get([x, y]) },
                             DepthStrategy::IfMoreWrite | DepthStrategy::IfMoreNoWrite =>
-                                z_lerped > unsafe { *depth.get([x, y]) },
+                                z_lerped > unsafe { depth.get([x, y]) },
                             DepthStrategy::None => true,
                         };
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -38,8 +38,8 @@ impl<T: Clone> Target for Texture2d<T> {
     }
 
     #[inline(always)]
-    unsafe fn get(&self, pos: [usize; 2]) -> &Self::Item {
-        &self.items.get_unchecked(pos[1] * self.size[0] + pos[0])
+    unsafe fn get(&self, pos: [usize; 2]) -> Self::Item {
+        self.items.get_unchecked(pos[1] * self.size[0] + pos[0]).clone()
     }
 
     fn clear(&mut self, fill: Self::Item) {


### PR DESCRIPTION
I ran into a problem today and this PR aims to help address that.

I actually noticed that the documentation for `get()` in the `Target` trait in some ways reflects the change I'm currently proposing: (emphasis mine)

> Get a **copy** of the item at the specified location in the target. The validity of the location is not checked, and as such this method is marked unsafe.

It says "copy", but the `get()` method currently returns a reference. Furthermore, if you [search for `get()`](https://github.com/zesterer/euc/search?utf8=%E2%9C%93&q=get&type=) in the repo, all its usages are immediately dereferenced. That means that we could potentially just return a clone and remove those dereferences.

This PR changes the `get()` method in the `Target` trait to return `Self::Item` instead of `&Self::Item`. It then makes any related changes to other parts of the code.

## Use Case

The reason I'm suggesting this is because I actually ran into a situation today where I really need this trait to return `Self::Item` instead of a reference.

The problem I have is in some FFI code. I have some shared memory represented as `Vec<u8>` and I use a `euc::Pipeline` implementation that returns `vek::Rgba<f32>`. The `Vec<u8>` is laid out in quadruples of (r, g, b, a). 

Rather than maintaining a separate `Buffer2d<Rgba<f32>>`, I want to avoid copying and just use the `Vec<u8>` directly. I can implement `set()` very easily, but implementing `get()` is impossible because I can't return a `&Rgba<f32>` from `&[u8]`. I can however return `Rgba<f32>`.

The changes in this PR would make `euc` usable for me in this case. 

## Impact of this change

I think the clone has minimal cost in almost all circumstances and will probably be optimized away. The only time `get()` is used in the various rasterizers is for the depth buffer anyway. That almost always has type `Buffer2d<f32>` and cloning an `f32` should be very cheap.

This would be a breaking change, so `0.3` would need to be released, but hopefully that is no big deal.

---

If you decide to merge this PR and my other one (#2) with no changes required, could you please release a new 0.3 of euc? Thank you :)