### PR TITLE
Added a benchmark using criterion.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ vek = "0.9"
 [dev-dependencies]
 minifb = "0.11"
 tobj = "0.1"
+criterion = "0.2"
+
+[lib]
+bench = false
+
+[[bench]]
+name = "teapot"
+harness = false
 
 [features]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ harness = false
 
 [features]
 nightly = []
+
+[profile.dev]
+# Optimize by default so we don't need to remember to always pass in --release
+opt-level = 3

--- a/benches/teapot.rs
+++ b/benches/teapot.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+
+use criterion::{Criterion, Bencher, criterion_group, criterion_main};
+use euc::{
+    Pipeline,
+    rasterizer,
+    buffer::Buffer2d,
+};
+use tobj;
+use vek::*;
+
+struct Teapot<'a> {
+    mvp: Mat4<f32>,
+    positions: &'a [Vec3<f32>],
+    normals: &'a [Vec3<f32>],
+    light_dir: Vec3<f32>,
+}
+
+impl<'a> Pipeline for Teapot<'a> {
+    type Vertex = u32; // Vertex index
+    type VsOut = Vec3<f32>; // Normal
+    type Pixel = u32; // BGRA
+
+    #[inline(always)]
+    fn vert(&self, v_index: &Self::Vertex) -> ([f32; 3], Self::VsOut) {
+        let v_index = *v_index as usize;
+        // Find vertex position
+        let v_pos = self.positions[v_index] + Vec3::new(0.0, -0.5, 0.0); // Offset to center the teapot
+        (
+            // Calculate vertex position in camera space
+            Vec3::from(self.mvp * Vec4::from_point(v_pos)).into_array(),
+            // Find vertex normal
+            self.normals[v_index],
+        )
+    }
+
+    #[inline(always)]
+    fn frag(&self, norm: &Self::VsOut) -> Self::Pixel {
+        let ambient = 0.2;
+        let diffuse = norm.dot(self.light_dir).max(0.0) * 0.5;
+        let specular = self.light_dir.reflected(Vec3::from(self.mvp * Vec4::from(*norm)).normalized()).dot(-Vec3::unit_z()).powf(20.0);
+
+        let light = ambient + diffuse + specular;
+        let color = (Rgba::new(1.0, 0.7, 0.1, 1.0) * light).clamped(Rgba::zero(), Rgba::one());
+
+        let bytes = (color * 255.0).map(|e| e as u8).into_array();
+        (bytes[2] as u32) << 0 |
+        (bytes[1] as u32) << 8 |
+        (bytes[0] as u32) << 16 |
+        (bytes[3] as u32) << 24
+    }
+}
+
+fn teapot_benchmark(b: &mut Bencher, &[width, height]: &[usize; 2]) {
+    let mut color = Buffer2d::new([width, height], 0);
+    let mut depth = Buffer2d::new([width, height], 1.0);
+
+    let obj = tobj::load_obj(&Path::new("examples/data/teapot.obj")).unwrap();
+    let indices = &obj.0[0].mesh.indices;
+    let positions = obj.0[0].mesh.positions.chunks(3).map(|sl| Vec3::from_slice(sl)).collect::<Vec<_>>();
+    let normals = obj.0[0].mesh.normals.chunks(3).map(|sl| Vec3::from_slice(sl)).collect::<Vec<_>>();
+
+    let mvp =
+        Mat4::perspective_rh_no(1.3, (width as f32)/(height as f32), 0.01, 100.0) *
+        Mat4::<f32>::scaling_3d(0.8) *
+        Mat4::rotation_x(0.002f32.sin() * 8.0) *
+        Mat4::rotation_y(0.004f32.cos() * 4.0) *
+        Mat4::rotation_z(0.008f32.sin() * 2.0);
+
+    let shader = Teapot {
+        mvp,
+        positions: &positions,
+        normals: &normals,
+        light_dir: Vec3::new(1.0, 1.0, 1.0).normalized(),
+    };
+
+    b.iter(|| {
+        shader.draw::<rasterizer::Triangles<_>, _>(
+            indices,
+            &mut color,
+            &mut depth,
+        );
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs("teapot", |b, &size| teapot_benchmark(b, size),
+        &[[32, 32], [200, 200], [640, 480], [800, 600], [1024, 800]]);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a benchmark to measure the time it takes to render the teapot example at various resolutions. The benchmark uses [criterion.rs](https://bheisler.github.io/criterion.rs/book/criterion_rs.html) and works on stable. Read the guide for that library for more information/usage.

This is very useful when testing potential performance enhancements. As an example, I tried to optimize the triangle rasterizer by removing the branching on the depth strategy on every iteration. The depth strategy doesn't change during the rasterization process, so we can use a closure (which will get inlined) to do this instead. [The changes and results are here.](https://github.com/sunjay/euc/commit/2332362d4d0eaa32616e531f06905dbb79379cd5) While we got some significant improvements for a few resolutions, it was not an improvement across the board. Thus, I did not submit that as part of this PR.

![image](https://user-images.githubusercontent.com/530939/57032347-62393d00-6c07-11e9-8278-bb90573e78b8.png)

I also snuck in a second change to set `opt-level = 3` in Cargo.toml. This just saves us from having to pass in `--release` all the time. Users of this library will still have to do that. It's just a quality of life improvement for us during development.

---

P.S. I think you may have some unpushed changes. The Cargo.toml file still lists version `0.2`. I can rebase this branch once you've pushed.