### PR TITLE
Implement proper `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,13 @@ exclude = [
 ]
 
 [dependencies]
-vek = "0.9.9"
+num-traits = { version = "0.2.11", default-features = false, optional = true }
+vek = { version = "0.10.0", default-features = false, features = ["rgb", "rgba"] }
+
+[features]
+default = ["std"]
+std = ["vek/std"]
+libm = ["vek/libm", "num-traits"]
 
 [dev-dependencies]
 minifb = "0.11"
@@ -28,9 +34,6 @@ bench = false
 [[bench]]
 name = "teapot"
 harness = false
-
-[features]
-nightly = []
 
 [profile.dev]
 # Optimize by default so we don't need to remember to always pass in --release

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ performance of software rendering tends to suffer. To experience this project wi
 
 ## `no_std`
 
-`euc` can be compiled on platforms that lack standard library supports. This makes it ideal for rendering 3D graphics on embedded devices.
-You can enable `no_std` support by enabling the `nightly` feature in your `Cargo.toml` file like so:
+`euc` can be compiled on platforms that lack standard library support. This makes it ideal for rendering 3D graphics on embedded devices.
+You can enable `no_std` support by disabling the default features and enabling the `libm` feature in your `Cargo.toml` file like so:
 
-```
+```toml
 [dependencies]
-euc = { version = "x.y.z", features = ["nightly"] }
+euc = { version = "x.y.z", default-features = false, features = ["libm"] }
 ```
 
 ## Goals

--- a/benches/teapot.rs
+++ b/benches/teapot.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use euc::{buffer::Buffer2d, rasterizer, Pipeline};
 use std::{path::Path, time::Duration};
-use tobj;
 use vek::*;
 
 struct Teapot<'a> {

--- a/examples/spinning_cube.rs
+++ b/examples/spinning_cube.rs
@@ -1,5 +1,4 @@
 use euc::{buffer::Buffer2d, rasterizer, Pipeline, Target};
-use minifb;
 use vek::*;
 
 struct Cube<'a> {

--- a/examples/teapot.rs
+++ b/examples/teapot.rs
@@ -1,7 +1,5 @@
 use euc::{buffer::Buffer2d, rasterizer, Pipeline, Target};
-use minifb;
 use std::path::Path;
-use tobj;
 use vek::*;
 
 struct Teapot<'a> {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -1,5 +1,4 @@
 use euc::{buffer::Buffer2d, rasterizer, DepthStrategy, Pipeline};
-use minifb;
 
 struct Triangle;
 

--- a/examples/wireframes.rs
+++ b/examples/wireframes.rs
@@ -1,7 +1,5 @@
 use euc::{buffer::Buffer2d, rasterizer, Pipeline, Target};
-use minifb;
 use std::path::Path;
-use tobj;
 use vek::*;
 
 struct Teapot<'a> {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 
-#[cfg(feature = "nightly")]
-use alloc::prelude::*;
+use alloc::vec::Vec;
 
 use crate::Target;
 

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,11 +1,12 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// A trait used to enable types to be interpolated throughout the rasterization process
 pub trait Interpolate {
     /// Linearly scale two items of this type and sum them
-    #[inline(always)]
     fn lerp2(a: Self, b: Self, x: f32, y: f32) -> Self;
 
     /// Linearly scale three items of this type and sum them
-    #[inline(always)]
     fn lerp3(a: Self, b: Self, c: Self, x: f32, y: f32, z: f32) -> Self;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#![cfg_attr(feature = "nightly", no_std)]
-#![cfg_attr(feature = "nightly", feature(alloc))]
+#![no_std]
 
-#[cfg(feature = "nightly")]
 #[macro_use]
 extern crate alloc;
 
@@ -52,11 +50,9 @@ where
     type Pixel: Clone;
 
     /// The vertex shader
-    #[inline(always)]
     fn vert(&self, vertex: &Self::Vertex) -> ([f32; 4], Self::VsOut);
 
     /// The fragment shader
-    #[inline(always)]
     fn frag(&self, vs_out: &Self::VsOut) -> Self::Pixel;
 
     /// A method used to determine what depth buffer strategy should be used when determining
@@ -90,17 +86,14 @@ pub trait Target {
     type Item: Clone;
 
     /// Get the dimensions of the target.
-    #[inline(always)]
     fn size(&self) -> [usize; 2];
 
     /// Set the item at the specified location in the target to the given item. The validity of the
     /// location is not checked, and as such this method is marked `unsafe`.
-    #[inline(always)]
     unsafe fn set(&mut self, pos: [usize; 2], item: Self::Item);
 
     /// Get a copy of the item at the specified location in the target. The validity of the
     /// location is not checked, and as such this method is marked `unsafe`.
-    #[inline(always)]
     unsafe fn get(&self, pos: [usize; 2]) -> Self::Item;
 
     /// Clear the target with copies of the specified item.

--- a/src/rasterizer/lines.rs
+++ b/src/rasterizer/lines.rs
@@ -1,4 +1,4 @@
-use self::super::*;
+use super::*;
 use crate::{Interpolate, Pipeline, Target};
 use core::marker::PhantomData;
 use vek::*;

--- a/src/rasterizer/triangles.rs
+++ b/src/rasterizer/triangles.rs
@@ -1,7 +1,9 @@
-use self::super::*;
+use super::*;
 use crate::{Interpolate, Pipeline, Target};
 use core::marker::PhantomData;
-use vek::*;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+use vek::{Mat3, Vec2, Vec3};
 
 /// A rasterizer that produces filled triangles from groups of 3 consecutive vertices.
 ///

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nightly")]
 use alloc::prelude::*;
 
 use crate::{


### PR DESCRIPTION
While the crate claimed to support `no_std` this didn't seem to be true. However with the stabilization of alloc last year, more and more crates have added support for `no_std`. vek 0.10 just released with `no_std` support, so euc can now finally properly support `no_std` as well.