### PR TITLE
Replaced `bresenham` with `clipline` (untested)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ image_ = { package = "image", version = "0.24", optional = true }
 num_cpus = { version = "1.13", optional = true }
 fxhash = { version = "0.2", optional = true }
 micromath_ = { package = "micromath", version = "1.1", optional = true }
-bresenham = "0.1"
+clipline = { version = "0.1.0" }
 
 [features]
 default = ["std", "image", "par"]

--- a/examples/wireframes.rs
+++ b/examples/wireframes.rs
@@ -1,7 +1,7 @@
 use derive_more::{Add, Mul};
 use euc::{
-    AaMode, Buffer2d, Clamped, DepthMode, Empty, Linear, Pipeline, PixelMode, Sampler, Target,
-    Texture, TriangleList, Unit,
+    AaMode, Buffer2d, Clamped, DepthMode, Empty, LineTriangleList, Linear, Pipeline, PixelMode,
+    Sampler, Target, Texture, Unit,
 };
 use minifb::{Key, MouseButton, MouseMode, Window, WindowOptions};
 use std::marker::PhantomData;
@@ -24,7 +24,7 @@ struct VertexData {
 impl<'a> Pipeline for Teapot<'a> {
     type Vertex = wavefront::Vertex<'a>;
     type VertexData = VertexData;
-    type Primitives = TriangleList; //Lines;
+    type Primitives = LineTriangleList;
     type Fragment = Rgba<f32>;
     type Pixel = u32;
 


### PR DESCRIPTION
Replaced the `bresenham` crate with `clipline`, which implements Bresenham's algorithm with built-in clipping. Unfortunately, I couldn't find a quick way to test it.